### PR TITLE
Ehancement/region schedule

### DIFF
--- a/ec2.py
+++ b/ec2.py
@@ -11,7 +11,7 @@ class EC2Instance(object):
         self.expires = False
         self.expired = False
         self.managed = False
-        self.schedued = True
+        self.scheduled = True
         self.validate()
         self._checkExpires()
         self._checkManaged()

--- a/ec2.py
+++ b/ec2.py
@@ -118,10 +118,10 @@ class EC2Instance(object):
         scheduled = True
         now = datetime.now()
         if self.properties['Availability'] == 'weekday':
-            if now.weekday() not in range(0,5) or now.hour not in range(7,19):
+            if now.weekday() not in range(0,5) or now.hour not in range(7,20):
                 scheduled = False
         elif self.properties['Availability'] == 'out-of-hours':
-            if now.weekday() in range(0,5) or now.hour in range(7,19):
+            if now.weekday() in range(0,5) or now.hour in range(7,20):
                 scheduled = False
         self.scheduled = scheduled
         return

--- a/ec2.py
+++ b/ec2.py
@@ -117,10 +117,29 @@ class EC2Instance(object):
         """ Checks if machine is scheduled to be available """
         scheduled = True
         now = datetime.now()
-        if self.properties['Availability'] == 'weekday':
+
+        # Default schedules for each environment
+        defaults = {
+        'development': 'weekday',
+        'integration': 'weekday',
+        'preview':     'weekday',
+        'preproduction' 'always',
+        'production':   'always'
+        }
+
+        # Set availability from tag if it's available.
+        availability = self.properties['Availability']
+
+        # If availability is simply set as default, look up what the default
+        # schedule is for that environment.
+        if availability == 'default':
+            availability = defaults[environment]
+
+        # Identify if the instance should be running based on it's schedule.
+        if availability == 'weekday':
             if now.weekday() not in range(0,5) or now.hour not in range(7,20):
                 scheduled = False
-        elif self.properties['Availability'] == 'out-of-hours':
+        elif availability == 'out-of-hours':
             if now.weekday() in range(0,5) or now.hour in range(7,20):
                 scheduled = False
         self.scheduled = scheduled


### PR DESCRIPTION
To take advantage of the 'default' schedule setting, I've added environment-specific schedules for use when an instance schedule is set to 'default'.

In this initial configuration everything other than `production` and `preproduction` environment tags will be set to a `weekday` schedule.