### PR TITLE
Added everyday schedule to EC2

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,5 +45,14 @@ objects and allows for some intelligent management of services.
 
 Expires should be set to UTC dates.
 
+## Availability:
+
+The following schedules are available:
+- `always` *instances run on 24/7 operation*
+- `weekdays` *instances run between 07:00 and 20:00 Monday to Friday*
+- `out-of-hours` *instances run on the opposite schedule to `weekdays`*
+- `everyday` *instances run between 07:00 and 22:00 every day*
+- `default` *schedule depends on environment tag*
+
 environment:  production / preproduction / preview / integration / development  
 availability: always / weekdays/ out-of-hours / default

--- a/ec2.py
+++ b/ec2.py
@@ -66,7 +66,7 @@ class EC2Instance(object):
             'Expires'
         ]
         strict = {
-            'Availability': ['default', 'always', 'weekdays', 'out-of-hours'],
+            'Availability': ['default', 'always', 'weekdays', 'out-of-hours', 'everyday'],
             'Environment': ['development', 'integration', 'preview', 'preproduction', 'production'],
             'Managed': ['yes', 'no']
         }
@@ -144,6 +144,9 @@ class EC2Instance(object):
                 scheduled = False
         elif availability == 'out-of-hours':
             if now.weekday() in workingdays and now.hour in workinghours:
+                scheduled = False
+        elif availability == 'everyday':
+            if now.hour < 7 or now.hour > 22: # 07:00-22:00 on any day of the week.
                 scheduled = False
         self.scheduled = scheduled
         return


### PR DESCRIPTION
As per Seb's request for an additional 'long day' schedule I've added a new schedule that powers down instances outside of 07:00-22:00 each day of the week.